### PR TITLE
Update Jira issue degradation automation guide

### DIFF
--- a/automations-scorecard-examples/create-jira-issue-when-rule-result-degraded/README.md
+++ b/automations-scorecard-examples/create-jira-issue-when-rule-result-degraded/README.md
@@ -12,6 +12,3 @@ In your GitHub repository, go to `Settings`>`Secrets` and add the following secr
 - `PORT_CLIENT_ID` - Your port [client id](https://docs.getport.io/build-your-software-catalog/custom-integration/api/#find-your-port-credentials)
 - `PORT_CLIENT_SECRET` - Your port [client secret](https://docs.getport.io/build-your-software-catalog/custom-integration/api/#find-your-port-credentials)
 
-#### Jira project key
-
-Make sure to replace `<YOUR-PROJECT-KEY>` in the GitHub workflow with your [Jira project key](https://confluence.atlassian.com/adminjiraserver/defining-a-project-938847066.html)

--- a/automations-scorecard-examples/create-jira-issue-when-rule-result-degraded/automation.json
+++ b/automations-scorecard-examples/create-jira-issue-when-rule-result-degraded/automation.json
@@ -10,8 +10,8 @@
     "condition": {
       "type": "JQ",
       "expressions": [
-        ".diff.before.properties.passed == \"Passed\"",
-        ".diff.after.properties.passed == \"Not passed\""
+        ".diff.before.properties.result == \"Passed\"",
+        ".diff.after.properties.result == \"Not passed\""
       ],
       "combinator": "and"
     }
@@ -22,6 +22,7 @@
     "repo": "github-repo-name",
     "workflow": "create-jira-issue-on-rule-degradation.yaml",
     "workflowInputs": {
+      "rule_result": "{{ .event.diff.after }}",
       "rule_result_name": "{{ .event.context.entityIdentifier }}",
       "entity_link": "{{ .event.diff.after.properties.entity_link }}",
       "runId": "{{ .run.id }}"

--- a/automations-scorecard-examples/create-jira-issue-when-rule-result-degraded/create-jira-issue-on-rule-degradation.yaml
+++ b/automations-scorecard-examples/create-jira-issue-when-rule-result-degraded/create-jira-issue-on-rule-degradation.yaml
@@ -3,6 +3,10 @@ name: Create issue when rule is degraded
 on:
   workflow_dispatch:
     inputs:
+      rule_result:
+        description: 'The rule reesult entity'
+        required: true
+        type: string
       rule_result_name:
         description: 'The rule result name'
         required: true
@@ -31,7 +35,7 @@ jobs:
       id: create
       uses: atlassian/gajira-create@v3
       with:
-        project: <YOUR-PROJECT-KEY>
+        project: ${{ fromJson(inputs.rule_result).relations.jiraProject }}
         issuetype: Task
         summary:  "Automation task - degraded rule result: ${{ inputs.rule_result_name }}"
         description: |

--- a/automations-scorecard-examples/send-message-when-rule-result-updated/notify-rule-result-updated.yaml
+++ b/automations-scorecard-examples/send-message-when-rule-result-updated/notify-rule-result-updated.yaml
@@ -5,11 +5,11 @@ on:
     inputs:
       # Note that the inputs are the same as the payload (workflowInputs) defined in the automation
       rule_result_name:
-        description: 'The rule result's name'
+        description: "The rule result's name"
         required: true
         type: string
       entity_link:
-        description: 'A link to the evaluated entity'
+        description: "A link to the evaluated entity"
         required: true
         type: string
 


### PR DESCRIPTION
Updated the create Jira issue when scorecard rule result degrade guide so that it doe not requires users to set their Jira project key manually in the workflow. This updates will makes the automation generic to any Jira project.